### PR TITLE
Add skill-scanner install step

### DIFF
--- a/lib/cluster.sh
+++ b/lib/cluster.sh
@@ -24,6 +24,10 @@ source "$SCRIPT_DIR/download.sh"
 source "$SCRIPT_DIR/config_manager.sh"
 source "$SCRIPT_DIR/java_manager.sh"
 source "$SCRIPT_DIR/process_manager.sh"
+if [ -f "$SCRIPT_DIR/skill_scanner_install.sh" ]; then
+    # shellcheck source=skill_scanner_install.sh
+    source "$SCRIPT_DIR/skill_scanner_install.sh"
+fi
 
 # ============================================================================
 # Global Variables
@@ -308,6 +312,15 @@ create_cluster() {
     cat "$cluster_conf" | while read line; do
         echo "  $line"
     done
+    echo ""
+
+    print_info "Post-config: optional Cisco skill-scanner step (Nacos ${VERSION})..."
+    echo "[nacos-setup/skill-scanner] cluster: post-config reached (VERSION=${VERSION})" >&2
+    if declare -F run_post_nacos_config_skill_scanner_hook >/dev/null 2>&1; then
+        run_post_nacos_config_skill_scanner_hook
+    else
+        echo "[nacos-setup/skill-scanner] ERROR: run_post_nacos_config_skill_scanner_hook missing; add lib/skill_scanner_install.sh to $SCRIPT_DIR" >&2
+    fi
     echo ""
     
     # Start all nodes
@@ -654,6 +667,15 @@ join_cluster() {
     
     rm -f "$config_file.bak"
     print_info "Node configured: main=$new_main_port, console=$new_console_port"
+    echo ""
+
+    print_info "Post-config: optional Cisco skill-scanner step (Nacos ${VERSION})..."
+    echo "[nacos-setup/skill-scanner] cluster join: post-config reached (VERSION=${VERSION})" >&2
+    if declare -F run_post_nacos_config_skill_scanner_hook >/dev/null 2>&1; then
+        run_post_nacos_config_skill_scanner_hook
+    else
+        echo "[nacos-setup/skill-scanner] ERROR: run_post_nacos_config_skill_scanner_hook missing; add lib/skill_scanner_install.sh to $SCRIPT_DIR" >&2
+    fi
     echo ""
     
     # Update cluster.conf in existing nodes

--- a/lib/skill_scanner_install.sh
+++ b/lib/skill_scanner_install.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Copyright 1999-2025 Alibaba Group Holding Ltd.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+# Optional Cisco skill-scanner (https://github.com/cisco-ai-defense/skill-scanner)
+# PyPI: cisco-ai-skill-scanner — requires Python 3.10+ and uv (recommended) or pip.
+# When invoked via "sudo nacos-setup", Python/uv/pip are resolved in SUDO_USER's
+# environment (same as running without sudo), so Homebrew/user installs are visible.
+
+SKILL_SCANNER_PYPI_PACKAGE="cisco-ai-skill-scanner"
+MIN_NACOS_VERSION_FOR_SKILL_SCANNER="3.2.0"
+_SKILL_SCANNER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Always write to stderr (no ANSI); survives logging pipelines and makes sudo/root issues obvious.
+_skill_scanner_trace() { printf '%s\n' "[nacos-setup/skill-scanner] $*" >&2; }
+
+# Entry from standalone.sh / cluster.sh after application.properties is written.
+run_post_nacos_config_skill_scanner_hook() {
+    _skill_scanner_trace "hook invoked (VERSION=${VERSION:-unset}, lib_dir=${_SKILL_SCANNER_LIB_DIR})"
+    if declare -F post_nacos_config_hook >/dev/null 2>&1; then
+        post_nacos_config_hook
+        return $?
+    fi
+    if declare -F maybe_install_skill_scanner_for_nacos >/dev/null 2>&1; then
+        maybe_install_skill_scanner_for_nacos "$VERSION"
+        return $?
+    fi
+    _skill_scanner_trace "no post_nacos_config_hook and no maybe_install_skill_scanner_for_nacos (broken or partial install)"
+    return 0
+}
+
+# Run as the user who invoked sudo (so PATH/HOME match a normal login).
+_skill_scanner_runas_target_user() {
+    if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && command -v sudo >/dev/null 2>&1; then
+        sudo -u "$SUDO_USER" -H "$@"
+    else
+        "$@"
+    fi
+}
+
+_find_python_310_plus() {
+    local out
+    if ! out=$(_skill_scanner_runas_target_user bash -c '
+        for c in python3.13 python3.12 python3.11 python3.10 python3; do
+            if command -v "$c" >/dev/null 2>&1 && "$c" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null; then
+                command -v "$c"
+                exit 0
+            fi
+        done
+        exit 1
+    ' 2>/dev/null); then
+        return 1
+    fi
+    echo "$out" | tail -n 1
+}
+
+_skill_scanner_already_installed() {
+    local py_exe=$1
+    if _skill_scanner_runas_target_user bash -c 'command -v skill-scanner >/dev/null 2>&1'; then
+        return 0
+    fi
+    if _skill_scanner_runas_target_user "$py_exe" -m pip show "$SKILL_SCANNER_PYPI_PACKAGE" >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+_install_skill_scanner_uv() {
+    local py_exe=$1
+    _skill_scanner_runas_target_user uv pip install --python "$py_exe" "$SKILL_SCANNER_PYPI_PACKAGE"
+}
+
+_install_skill_scanner_pip() {
+    local py_exe=$1
+    _skill_scanner_runas_target_user "$py_exe" -m pip install --user "$SKILL_SCANNER_PYPI_PACKAGE"
+}
+
+_skill_scanner_ensure_version_ge() {
+    if declare -F version_ge >/dev/null 2>&1; then
+        return 0
+    fi
+    if [ -f "$_SKILL_SCANNER_LIB_DIR/common.sh" ]; then
+        # shellcheck source=common.sh
+        source "$_SKILL_SCANNER_LIB_DIR/common.sh"
+    fi
+    declare -F version_ge >/dev/null 2>&1
+}
+
+# When Nacos Server version >= 3.2.0, ensure skill-scanner is available (best-effort).
+# Set NACOS_SETUP_SKIP_SKILL_SCANNER=1 to disable.
+maybe_install_skill_scanner_for_nacos() {
+    local nacos_version="${1:-}"
+    _skill_scanner_trace "maybe_install_skill_scanner_for_nacos nacos_version='${nacos_version}'"
+
+    if [ "${NACOS_SETUP_SKIP_SKILL_SCANNER:-}" = "1" ] || [ "${NACOS_SETUP_SKIP_SKILL_SCANNER:-}" = "true" ]; then
+        _skill_scanner_trace "skip: NACOS_SETUP_SKIP_SKILL_SCANNER is set"
+        return 0
+    fi
+
+    if [ -z "$nacos_version" ]; then
+        _skill_scanner_trace "skip: empty nacos_version"
+        return 0
+    fi
+
+    if ! _skill_scanner_ensure_version_ge; then
+        _skill_scanner_trace "skip: version_ge unavailable (missing lib/common.sh?)"
+        print_warn "skill-scanner step skipped: version_ge unavailable (reinstall nacos-setup from a build that includes lib/common.sh)"
+        return 0
+    fi
+
+    if ! version_ge "$nacos_version" "$MIN_NACOS_VERSION_FOR_SKILL_SCANNER"; then
+        _skill_scanner_trace "skip: nacos ${nacos_version} < ${MIN_NACOS_VERSION_FOR_SKILL_SCANNER} (no skill-scanner step)"
+        return 0
+    fi
+
+    print_info "Nacos ${nacos_version} >= ${MIN_NACOS_VERSION_FOR_SKILL_SCANNER}: checking Cisco skill-scanner (${SKILL_SCANNER_PYPI_PACKAGE})..."
+    if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ]; then
+        print_info "sudo detected: using user ${SUDO_USER}'s environment for Python / pip / uv (root often lacks Homebrew Python)."
+    fi
+
+    local py_exe
+    py_exe=$(_find_python_310_plus) || {
+        print_warn "skill-scanner needs Python 3.10+ on PATH for your user. Install Python 3.10+ with pip or uv, then: pip install --user ${SKILL_SCANNER_PYPI_PACKAGE}"
+        print_warn "Reference: https://github.com/cisco-ai-defense/skill-scanner"
+        return 0
+    }
+
+    if _skill_scanner_already_installed "$py_exe"; then
+        print_info "skill-scanner already installed (skip)."
+        return 0
+    fi
+
+    if ! _skill_scanner_runas_target_user bash -c 'command -v uv >/dev/null 2>&1' \
+        && ! _skill_scanner_runas_target_user "$py_exe" -m pip --version >/dev/null 2>&1; then
+        print_warn "Neither uv nor pip is available for Python at ${py_exe}. Install uv or pip for Python 3.10+."
+        return 0
+    fi
+
+    if _skill_scanner_runas_target_user bash -c 'command -v uv >/dev/null 2>&1'; then
+        print_info "Installing ${SKILL_SCANNER_PYPI_PACKAGE} with uv..."
+        if _install_skill_scanner_uv "$py_exe"; then
+            print_info "Installed ${SKILL_SCANNER_PYPI_PACKAGE} via uv."
+            return 0
+        fi
+        print_warn "uv install failed, trying pip..."
+    fi
+
+    print_info "Installing ${SKILL_SCANNER_PYPI_PACKAGE} with pip..."
+    if _install_skill_scanner_pip "$py_exe"; then
+        print_info "Installed ${SKILL_SCANNER_PYPI_PACKAGE} via pip."
+        print_info "If skill-scanner is not in PATH, add ~/.local/bin or run: ${py_exe} -m skill_scanner"
+        return 0
+    fi
+
+    print_warn "Could not install ${SKILL_SCANNER_PYPI_PACKAGE}. Install manually: pip install --user ${SKILL_SCANNER_PYPI_PACKAGE}"
+    print_warn "Docs: https://github.com/cisco-ai-defense/skill-scanner"
+    return 0
+}

--- a/lib/standalone.sh
+++ b/lib/standalone.sh
@@ -24,6 +24,10 @@ source "$SCRIPT_DIR/download.sh"
 source "$SCRIPT_DIR/config_manager.sh"
 source "$SCRIPT_DIR/java_manager.sh"
 source "$SCRIPT_DIR/process_manager.sh"
+if [ -f "$SCRIPT_DIR/skill_scanner_install.sh" ]; then
+    # shellcheck source=skill_scanner_install.sh
+    source "$SCRIPT_DIR/skill_scanner_install.sh"
+fi
 
 # ============================================================================
 # Global Variables for Standalone Mode
@@ -169,6 +173,16 @@ run_standalone_mode() {
     
     rm -f "$config_file.bak"
     print_info "Configuration completed"
+    echo ""
+
+    # stdout + stderr: some installs only surface [INFO]; stderr traces still go to skill_scanner_install.sh
+    print_info "Post-config: optional Cisco skill-scanner step (Nacos ${VERSION})..."
+    echo "[nacos-setup/skill-scanner] standalone: post-config reached (VERSION=${VERSION})" >&2
+    if declare -F run_post_nacos_config_skill_scanner_hook >/dev/null 2>&1; then
+        run_post_nacos_config_skill_scanner_hook
+    else
+        echo "[nacos-setup/skill-scanner] ERROR: run_post_nacos_config_skill_scanner_hook missing; add lib/skill_scanner_install.sh to $SCRIPT_DIR" >&2
+    fi
     echo ""
     
     # Start Nacos if auto-start is enabled

--- a/nacos-setup.sh
+++ b/nacos-setup.sh
@@ -435,6 +435,26 @@ validate_arguments() {
 }
 
 # ============================================================================
+# Skill-scanner post-install hook (lib/skill_scanner_install.sh)
+# Called from standalone/cluster after Nacos config is written. Pre-load here so
+# post_nacos_config_hook exists even if a partial/older lib omits the call path.
+# ============================================================================
+
+setup_skill_scanner_hook_for_nacos_install() {
+    if [ -f "$LIB_DIR/skill_scanner_install.sh" ]; then
+        # shellcheck source=lib/skill_scanner_install.sh
+        source "$LIB_DIR/skill_scanner_install.sh"
+    fi
+    post_nacos_config_hook() {
+        if declare -F maybe_install_skill_scanner_for_nacos >/dev/null 2>&1; then
+            maybe_install_skill_scanner_for_nacos "$VERSION"
+        else
+            echo "[nacos-setup/skill-scanner] skipped: missing $LIB_DIR/skill_scanner_install.sh (reinstall or copy from nacos-setup source tree)" >&2
+        fi
+    }
+}
+
+# ============================================================================
 # Main Entry Point
 # ============================================================================
 
@@ -488,6 +508,8 @@ main() {
     
     # Disable set -e for mode execution (they handle errors internally)
     set +e
+
+    setup_skill_scanner_hook_for_nacos_install
     
     # Route to appropriate mode
     case "$MODE" in

--- a/tests/test_standalone.sh
+++ b/tests/test_standalone.sh
@@ -72,6 +72,17 @@ else
     test_fail "standalone.sh not found"
 fi
 
+# 测试 6b: skill-scanner 后置钩子（stderr 可观测）
+if [ -f "$LIB_DIR/standalone.sh" ]; then
+    if grep -q "run_post_nacos_config_skill_scanner_hook" "$LIB_DIR/standalone.sh"; then
+        test_pass "Standalone mode invokes skill-scanner post-config hook"
+    else
+        test_fail "Standalone mode should call run_post_nacos_config_skill_scanner_hook"
+    fi
+else
+    test_fail "standalone.sh not found"
+fi
+
 # 测试 7: 检查单机模式数据源配置
 if [ -f "$LIB_DIR/standalone.sh" ]; then
     if grep -q "load_default_datasource_config\|apply_datasource_config" "$LIB_DIR/standalone.sh"; then


### PR DESCRIPTION
## Summary

Adds an **optional, best-effort** post-configuration step to install [Cisco skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) (PyPI: `cisco-ai-skill-scanner`) after `application.properties` is written in **standalone** and **cluster** (`create_cluster` / `join_cluster`) flows.

## Motivation

When Nacos Server is **≥ 3.2.0**, users may want `skill-scanner` available in the same environment where Nacos was set up. This change automates a conservative install attempt (uv preferred, pip fallback) without failing the main setup if Python/uv/pip is missing.

## Behavior

- **Version gate**: runs the install logic only when `VERSION` ≥ `3.2.0` (constant `MIN_NACOS_VERSION_FOR_SKILL_SCANNER`).
- **Python**: requires **Python 3.10+** on the target user’s `PATH` (probes `python3.13` … `python3`).
- **Package manager**: prefers **uv** (`uv pip install --python <py>`), falls back to **`pip install --user`**.
- **`sudo`**: when running as root with `SUDO_USER`, Python/uv/pip resolution uses `sudo -u "$SUDO_USER" -H` so Homebrew/user installs remain visible.
- **Opt-out**: set `NACOS_SETUP_SKIP_SKILL_SCANNER=1` or `true` to skip.
- **Non-fatal**: warnings only on skip/failure; Nacos setup continues.

## Implementation notes

- New module: `lib/skill_scanner_install.sh` (`run_post_nacos_config_skill_scanner_hook`, `maybe_install_skill_scanner_for_nacos`).
- `nacos-setup.sh`: `setup_skill_scanner_hook_for_nacos_install` preloads hook so older/partial `lib` trees still get `post_nacos_config_hook` when possible.
- `lib/standalone.sh` / `lib/cluster.sh`: conditional `source` of `skill_scanner_install.sh` and call after config write.
- Tests: `tests/test_standalone.sh` asserts standalone invokes `run_post_nacos_config_skill_scanner_hook`.

## How to test

1. Standalone install with Nacos **≥ 3.2.0**, Python **3.10+**, and `uv` or `pip` available → expect install attempt / “already installed” message.
2. `export NACOS_SETUP_SKIP_SKILL_SCANNER=1` → step skipped.
3. Nacos **&lt; 3.2.0** → step skipped without error.
4. Cluster `create` / `join` → same post-config hook runs after configuration.

## Checklist

- [x] Standalone + cluster paths covered
- [x] Documented opt-out env var in script comments
- [x] Test updated for hook presence