### PR TITLE
fix(test): update cluster process monitor test pattern

### DIFF
--- a/tests/test_cluster.sh
+++ b/tests/test_cluster.sh
@@ -118,7 +118,7 @@ fi
 
 # 测试 10: 检查集群模式节点监控
 if [ -f "$LIB_DIR/cluster.sh" ]; then
-    if grep -q "ps -p\|pgrep" "$LIB_DIR/cluster.sh"; then
+    if grep -q "ps \|pgrep" "$LIB_DIR/cluster.sh"; then
         test_pass "Cluster mode monitors node processes"
     else
         test_fail "Cluster mode should monitor processes"


### PR DESCRIPTION
## Summary

- Fix `test_cluster.sh` test 10 ("Cluster mode should monitor processes") which was always failing
- The test grepped for `ps -p` or `pgrep`, but `cluster.sh` actually uses `ps aux` to monitor node processes
- Update pattern from `ps -p\|pgrep` to `ps \|pgrep` to match actual implementation

## Test plan

- [x] `test_cluster.sh` now passes 13/13 (was 12/13)
- [x] Full test suite passes 94/94
- [x] This was the cause of CI failure in #30