### PR TITLE
fix: reuse installed Java before bundled JDK prompt

### DIFF
--- a/lib/bundled_jre_install.sh
+++ b/lib/bundled_jre_install.sh
@@ -13,6 +13,19 @@
 # Set NACOS_SETUP_SKIP_BUNDLED_JRE=1 to skip this step.
 # Set NACOS_SETUP_SKIP_AUTO_INSTALL_UNZIP=1 to refuse auto-installing unzip (fail if missing).
 
+BUNDLED_JRE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! declare -F search_java_installation >/dev/null 2>&1 && [ -f "$BUNDLED_JRE_SCRIPT_DIR/java_manager.sh" ]; then
+    _BUNDLED_JRE_CALLER_SCRIPT_DIR="${SCRIPT_DIR:-}"
+    # shellcheck source=lib/java_manager.sh
+    source "$BUNDLED_JRE_SCRIPT_DIR/java_manager.sh"
+    if [ -n "$_BUNDLED_JRE_CALLER_SCRIPT_DIR" ]; then
+        SCRIPT_DIR="$_BUNDLED_JRE_CALLER_SCRIPT_DIR"
+    else
+        unset SCRIPT_DIR
+    fi
+    unset _BUNDLED_JRE_CALLER_SCRIPT_DIR
+fi
+
 BUNDLED_JDK_CACHE_DIR="${NACOS_CACHE_DIR:-$HOME/.nacos/cache}"
 JDK17_OSS_BASE="https://download.nacos.io/base"
 
@@ -51,6 +64,36 @@ _java17_already_on_system() {
         fi
     fi
     return 1
+}
+
+_java17_search_and_apply_system_installation() {
+    if ! declare -F search_java_installation >/dev/null 2>&1; then
+        return 1
+    fi
+
+    local java_cmd java_home
+    java_cmd=$(search_java_installation 17 false) || return 1
+    [ -n "$java_cmd" ] || return 1
+
+    if ! _java_major_at_least_17 "$java_cmd"; then
+        return 1
+    fi
+
+    if declare -F resolve_java_home_from_cmd >/dev/null 2>&1; then
+        java_home=$(resolve_java_home_from_cmd "$java_cmd" || true)
+    fi
+    if [ -z "$java_home" ]; then
+        java_home="$(dirname "$(dirname "$java_cmd")")"
+    fi
+
+    if [ ! -x "$java_home/bin/java" ]; then
+        return 1
+    fi
+
+    export JAVA_HOME="$java_home"
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+    print_detail "Using system Java 17+ at JAVA_HOME=$JAVA_HOME"
+    return 0
 }
 
 # Map detect_os_arch -> OSS path segment (darwin | linux)
@@ -423,11 +466,15 @@ ensure_bundled_java17_for_nacos_setup() {
         return 0
     fi
 
+    if _java17_search_and_apply_system_installation; then
+        return 0
+    fi
+
     if _bundled_jre_reuse_if_present; then
         return 0
     fi
 
-    print_info "Nacos ${nacos_version} requires Java 17+. None found in JAVA_HOME or PATH."
+    print_info "Nacos ${nacos_version} requires Java 17+. None found in JAVA_HOME, PATH, or common Java install directories."
 
     if ! _confirm_bundled_jre_install; then
         print_info "Skipping bundled JDK installation. Exiting without starting Nacos setup."

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -351,7 +351,10 @@ get_java_search_paths() {
         linux)
             paths=(
                 "/usr/lib/jvm"
+                "/usr/local/lib/jvm"
                 "/usr/java"
+                "/usr/local/java"
+                "/usr/local/jdk"
                 "/opt/java"
                 "/opt/jdk"
                 "$HOME/.sdkman/candidates/java"
@@ -362,6 +365,8 @@ get_java_search_paths() {
             paths=(
                 "/Library/Java/JavaVirtualMachines"
                 "/System/Library/Frameworks/JavaVM.framework"
+                "/opt/homebrew/opt"
+                "/usr/local/opt"
                 "$HOME/.sdkman/candidates/java"
                 "$HOME/.jenv/versions"
             )
@@ -369,7 +374,10 @@ get_java_search_paths() {
         *)
             paths=(
                 "/usr/lib/jvm"
+                "/usr/local/lib/jvm"
                 "/usr/java"
+                "/usr/local/java"
+                "/usr/local/jdk"
                 "/opt/java"
                 "/Library/Java/JavaVirtualMachines"
             )

--- a/tests/test_java.sh
+++ b/tests/test_java.sh
@@ -61,5 +61,50 @@ else
     test_fail "cluster.sh not found"
 fi
 
+# 测试 6: bundled JDK 下载前应先复用系统扫描到的 Java 17+
+tmp_java_dir=$(mktemp -d 2>/dev/null || mktemp -d -t nacos-java-test)
+mock_java_home="$tmp_java_dir/jdk-21"
+mock_java="$mock_java_home/bin/java"
+mkdir -p "$mock_java_home/bin"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'echo "openjdk version \"21.0.2\" 2024-01-16" >&2' \
+    'exit 0' > "$mock_java"
+chmod +x "$mock_java"
+
+if (
+    source "$LIB_DIR/common.sh"
+
+    command() {
+        if [ "$1" = "-v" ] && [ "${2:-}" = "java" ]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+
+    search_java_installation() {
+        printf '%s\n' "$mock_java"
+    }
+
+    resolve_java_home_from_cmd() {
+        printf '%s\n' "$mock_java_home"
+    }
+
+    unset JAVA_HOME
+    source "$LIB_DIR/bundled_jre_install.sh"
+
+    _confirm_bundled_jre_install() {
+        return 1
+    }
+
+    ensure_bundled_java17_for_nacos_setup "3.2.0" >/dev/null 2>&1 &&
+        [ "$JAVA_HOME" = "$mock_java_home" ]
+); then
+    test_pass "Bundled JDK gate reuses scanned Java 21 before prompting"
+else
+    test_fail "Bundled JDK gate did not reuse scanned Java 21"
+fi
+rm -rf "$tmp_java_dir"
+
 echo ""
 test_summary


### PR DESCRIPTION
PR Body

  Please do not create a Pull Request without creating an issue first.

  ## What is the purpose of the change

  This PR improves the Nacos setup Java detection flow for Nacos 3.x. Before prompting users to download the bundled JDK 17, nacos-setup now scans common local Java installation directories and reuses an existing Java 17+ installation, such as Java 21, when available.

  ## Brief changelog

  - Reuse existing Java 17+ installations discovered by `search_java_installation` before prompting for bundled JDK 17.
  - Temporarily set `JAVA_HOME` and prepend the discovered Java `bin` directory to `PATH` for the current setup process when a valid system Java is found.
  - Expand common Java search paths for Linux and macOS, including `/usr/local/*` and Homebrew locations.
  - Add a regression test for the case where Java 21 is not exposed via `JAVA_HOME` or `PATH` but can be discovered by system scanning.

  ## Verifying this change

  - `bash tests/test_java.sh`
  - `bash tests/test_syntax.sh`
  - `bash test.sh`

  Follow this checklist to help us incorporate your contribution quickly and easily:

  * [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one
  issue.
  * [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
  * [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  * [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/
  nacos/tree/master/test).
  * [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.