### PR TITLE
Fix nacos-cli installer package path

### DIFF
--- a/nacos-installer.sh
+++ b/nacos-installer.sh
@@ -277,7 +277,7 @@ download_nacos_cli() {
     local os=$2
     local arch=$3
     local zip_filename="nacos-cli-${version}-${os}-${arch}.zip"
-    local download_url="${DOWNLOAD_BASE_URL}/${zip_filename}"
+    local download_url="${DOWNLOAD_BASE_URL}/nacos-cli/${zip_filename}"
     local cached_file="$CACHE_DIR/$zip_filename"
     
     # Create cache directory
@@ -540,9 +540,6 @@ install_nacos_cli() {
             return 1
             ;;
     esac
-    local url="${DOWNLOAD_BASE_URL}/nacos-cli-${version}-${os}-${arch}.zip"
-    local zip_filename="nacos-cli-${version}-${os}-${arch}.zip"
-    
     # Download nacos-cli (with caching)
     local zip_file=$(download_nacos_cli "$version" "$os" "$arch")
     
@@ -569,17 +566,21 @@ install_nacos_cli() {
         return 1
     fi
 
-    # Expected binary: nacos-cli-{version}-{os}-{arch}
-    local expected_binary_name="nacos-cli-${version}-${os}-${arch}"
-    local expected_binary_name_exe="${expected_binary_name}.exe"
+    # New packages contain a stable binary name; keep old names as fallback.
+    local expected_binary_name="nacos-cli"
+    local legacy_binary_name="nacos-cli-${version}-${os}-${arch}"
+    local legacy_binary_name_exe="${legacy_binary_name}.exe"
     local binary_path
     binary_path=$(find "$tmp_dir" -name "$expected_binary_name" -type f | head -1)
     if [ -z "$binary_path" ]; then
-        binary_path=$(find "$tmp_dir" -name "$expected_binary_name_exe" -type f | head -1)
+        binary_path=$(find "$tmp_dir" -name "$legacy_binary_name" -type f | head -1)
+    fi
+    if [ -z "$binary_path" ]; then
+        binary_path=$(find "$tmp_dir" -name "$legacy_binary_name_exe" -type f | head -1)
     fi
 
     if [ -z "$binary_path" ] || [ ! -f "$binary_path" ]; then
-        local expected_names="$expected_binary_name (or $expected_binary_name_exe)"
+        local expected_names="$expected_binary_name, $legacy_binary_name, or $legacy_binary_name_exe"
         print_error "Binary file not found in package. Expected: $expected_names"
         print_info "Available files in package:"
         find "$tmp_dir" -type f | sed 's|^|  |'

--- a/windows/nacos-installer.ps1
+++ b/windows/nacos-installer.ps1
@@ -462,10 +462,18 @@ if ($isAdmin) {
 function Install-NacosCli {
     Write-Info "Preparing to install nacos-cli $($Global:NacosCliVersion)..."
     $os   = "windows"
-    $arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+    $processorArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+    $arch = switch -Regex ($processorArch) {
+        "^(AMD64|X64|X86_64)$" { "amd64"; break }
+        "^(ARM64|AARCH64)$"    { "arm64"; break }
+        default {
+            Write-ErrorMsg "Unsupported architecture for nacos-cli: $processorArch"
+            return $false
+        }
+    }
     $zipName = "nacos-cli-$($Global:NacosCliVersion)-$os-$arch.zip"
     $zipPath = Join-Path $CacheDir $zipName
-    $dlUrl   = "$DownloadBaseUrl/$zipName"
+    $dlUrl   = "$DownloadBaseUrl/nacos-cli/$zipName"
 
     # Download with cache
     if (Test-ZipValid $zipPath) {
@@ -487,10 +495,14 @@ function Install-NacosCli {
         return $false
     }
 
-    $expected = "nacos-cli-$($Global:NacosCliVersion)-$os-$arch.exe"
-    $binary   = Get-ChildItem -Path $extractDir -Recurse -Filter $expected | Select-Object -First 1
+    $expected = "nacos-cli.exe"
+    $legacyExpected = "nacos-cli-$($Global:NacosCliVersion)-$os-$arch.exe"
+    $binary = Get-ChildItem -Path $extractDir -Recurse -Filter $expected | Select-Object -First 1
     if (-not $binary) {
-        Write-ErrorMsg "Binary not found in package. Expected: $expected"
+        $binary = Get-ChildItem -Path $extractDir -Recurse -Filter $legacyExpected | Select-Object -First 1
+    }
+    if (-not $binary) {
+        Write-ErrorMsg "Binary not found in package. Expected: $expected or $legacyExpected"
         Get-ChildItem -Path $extractDir -Recurse | ForEach-Object { Write-Info "  $($_.FullName)" }
         Remove-Item $extractDir -Recurse -Force
         return $false


### PR DESCRIPTION
## Summary

- update Bash and PowerShell installers to download nacos-cli packages from `/nacos-cli/`
- support the new stable binary names inside CLI zip packages (`nacos-cli`, `nacos-cli.exe`)
- keep legacy versioned binary names as fallback
- detect Windows arm64 packages instead of treating every 64-bit Windows host as amd64

## Verification

- `bash -n nacos-installer.sh`
- PowerShell parser was not run locally because `pwsh`/`powershell` is not installed on this machine
